### PR TITLE
Suppress legacy plugin warning by setting api-version to 1.13

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: NoHitDelay
 version: '1.1'
 main: newamazingpvp.nohitdelay.NoHitDelay
+api-version: 1.13
 commands:
   nohitdelay:
     description: Manage hit delay settings.


### PR DESCRIPTION
With the release of 1.13, Spigot made many notable changes to the Material enum that broke many older plugins. To combat this, they added a feature that automatically remaps old Material enums in legacy plugins to their modern equivalent. To know which plugins needed to be remapped, they also added the "api-version" field to the plugin.yml. Plugins missing this are considered legacy plugins, and will have their enums remapped and a warning giving in the console.

While this plugin is designed to work on versions older than 1.13, it doesn't touch the Material enum at all. Therefore it doesn't need the legacy material support feature. This PR simply marks that this plugin is not a legacy plugin to get rid of the console warning.